### PR TITLE
Updated login payload to request body

### DIFF
--- a/login-with-wallet-next/pages/api/login.tsx
+++ b/login-with-wallet-next/pages/api/login.tsx
@@ -21,7 +21,7 @@ const login = async (req: NextApiRequest, res: NextApiResponse) => {
   const sdk = ThirdwebSDK.fromPrivateKey(process.env.ADMIN_PRIVATE_KEY as string, "mainnet");
   
   // Get signed login payload from the frontend
-  const payload = req.body.payload as LoginPayload;
+  const payload = req.body as LoginPayload;
   if (!payload) {
     return res.status(400).json({ 
       error: "Must provide a login payload to generate a token" 


### PR DESCRIPTION
Updated login payload to request body instead of req.body.payload because req.body has the shape of the LoginPayload interface. 

```
// Get signed login payload from the frontend
  const payload = req.body.payload as LoginPayload;
  if (!payload) {
    return res.status(400).json({ 
      error: "Must provide a login payload to generate a token" 
    })
  }  
```

The above code block will change to 

```
 // Get signed login payload from the frontend
  const payload = req.body as LoginPayload;
  if (!payload) {
    return res.status(400).json({ 
      error: "Must provide a login payload to generate a token" 
    })
  }  
```



